### PR TITLE
Add a travis config, testing against Python 2.6/2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: python
+python:
+ - "2.6"
+ - "2.7"
+install: pip install -r requirements/tests.txt
+script: nosetests


### PR DESCRIPTION
This needs pull request #2 to be merged first, so that requirements/tests.txt exists and install nose.

It also relies on registering the project with travis-ci and enabling the github hook.
