### PR TITLE
Catch up with ISO name change for Cabo Verde.

### DIFF
--- a/mobile_codes/__init__.py
+++ b/mobile_codes/__init__.py
@@ -52,7 +52,7 @@ def _countries():
         Country(u"Cambodia", "KH", "KHM", "116", "456"),
         Country(u"Cameroon", "CM", "CMR", "120", "624"),
         Country(u"Canada", "CA", "CAN", "124", "302"),
-        Country(u"Cape Verde", "CV", "CPV", "132", "625"),
+        Country(u"Cabo Verde", "CV", "CPV", "132", "625"),
         Country(u"Cayman Islands", "KY", "CYM", "136", "346"),
         Country(u"Central African Republic", "CF", "CAF", "140", "623"),
         Country(u"Chad", "TD", "TCD", "148", "622"),


### PR DESCRIPTION
First seen in deactivated/python-iso3166@ac7c6cd297ae83659092b2e1f63713683c1fb0f4.

I've compared against the current version of all codes on the ISO website. There are only a couple of minor differences in using brackets or the inclusion of "the" in the short names, but no other changes.
