### PR TITLE
Changed mcc API to always return a list, closes #4.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,11 +29,12 @@ Usage
 Lookup by Mobile Country Code (MCC)::
 
     >>> mobile_codes.mcc("648")
-    Country(name=u'Zimbabwe', alpha2='ZW', alpha3='ZWE', numeric='716', mcc='648')
-    >>> mobile_codes.mcc("310")
-    Country(name=u'United States', alpha2='US', alpha3='USA', numeric='840', mcc=('310', '311', '313', '316'))
+    [Country(name=u'Zimbabwe', alpha2='ZW', alpha3='ZWE', numeric='716', mcc='648')]
+    >>> mobile_codes.mcc("311")
+    [Country(name=u'Guam', alpha2='GU', alpha3='GUM', numeric='316', mcc=('310', '311')),
+     Country(name=u'United States', alpha2='US', alpha3='USA', numeric='840', mcc=('310', '311', '313', '316'))]
     >>> mobile_codes.mcc("313")
-    Country(name=u'United States', alpha2='US', alpha3='USA', numeric='840', mcc=('310', '311', '313', '316'))
+    [Country(name=u'United States', alpha2='US', alpha3='USA', numeric='840', mcc=('310', '311', '313', '316'))]
 
 Lookup by name, alpha2, alpha3 (all case insensitive)::
 
@@ -68,6 +69,9 @@ If you want to do development on the library, follow these steps:
 
 Changes
 =======
+
+0.3: Changed mcc API to always return a list, possibly empty, possibly
+     containing multiple countries.
 
 0.2.2: Some tests, docs changes and updates to the records, thanks hannosch.
 

--- a/mobile_codes/__init__.py
+++ b/mobile_codes/__init__.py
@@ -2049,14 +2049,15 @@ def _build_index(idx, records):
 
 def _build_index_tuple(idx, records):
     # There can be multiple MCC codes per country
-    result = {}
+    # and there can be multiple countries for one MCC code
+    result = defaultdict(list)
     for r in records:
         if isinstance(r[idx], tuple):
             for k in r[idx]:
                 if k:
-                    result[k.upper()] = r
+                    result[k.upper()].append(r)
         elif r[idx]:
-            result[r[idx].upper()] = r
+            result[r[idx].upper()].append(r)
     return result
 
 

--- a/mobile_codes/tests.py
+++ b/mobile_codes/tests.py
@@ -6,17 +6,28 @@ import mobile_codes
 class TestCountries(TestCase):
 
     def test_mcc(self):
-        country = mobile_codes.mcc('302')
-        self.assertEqual(country.mcc, '302')
+        countries = mobile_codes.mcc('302')
+        self.assertEqual(len(countries), 1)
+        self.assertEqual(countries[0].mcc, '302')
 
-    def test_mcc_multiple(self):
-        country = mobile_codes.mcc('310')
-        self.assertEqual(country.mcc, ('310', '311', '313', '316'))
-        country = mobile_codes.mcc('313')
-        self.assertEqual(country.mcc, ('310', '311', '313', '316'))
+    def test_mcc_multiple_codes(self):
+        countries = mobile_codes.mcc('313')
+        self.assertEqual(len(countries), 1)
+        self.assertEqual(countries[0].mcc, ('310', '311', '313', '316'))
+
+        # We even get multiple countries with multiple MCC each
+        countries = mobile_codes.mcc('310')
+        self.assertTrue(len(countries) > 1)
+        for country in countries:
+            self.assertTrue(len(country.mcc) > 1)
+
+    def test_mcc_multiple_countries(self):
+        countries = mobile_codes.mcc('505')
+        self.assertEqual(len(countries), 2)
 
     def test_mcc_fail(self):
-        self.assertRaises(KeyError, mobile_codes.mcc, '000')
+        countries = mobile_codes.mcc('000')
+        self.assertEqual(len(countries), 0)
 
     def test_alpha2(self):
         country = mobile_codes.alpha2('CA')


### PR DESCRIPTION
I changed one readme example from mcc 310 to 311, as 310 returns three countries (Bermuda), which I found slightly less readable. Showing a two country example already highlights the main point.
