### PR TITLE
Declare and let travis test Python 3.3 compatibility.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,6 @@ language: python
 python:
  - "2.6"
  - "2.7"
+ - "3.3"
 install: pip install -r requirements/tests.txt
 script: nosetests

--- a/setup.py
+++ b/setup.py
@@ -16,5 +16,11 @@ setup(
         'Intended Audience :: Developers',
         'Natural Language :: English',
         'Operating System :: OS Independent',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
     ]
 )


### PR DESCRIPTION
Python 3.2 is currently not supported, as we are using the u-prefix, which was re-introduced in Python 3.3. Python 3.4 is not yet supported by travis.
